### PR TITLE
Get null files through

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var es = require('event-stream');
 var _ = require('lodash');
 var frontMatter = require('front-matter');
+var gutil = require('gulp-util');
+
+var PLUGIN_NAME = 'gulp-front-matter';
 
 module.exports = function (options) {
 
@@ -17,17 +20,19 @@ module.exports = function (options) {
       try {
         content = frontMatter(String(file.contents));
       } catch (e) {
-        return cb(e);
+        return cb(new gutil.PluginError(PLUGIN_NAME, e));
       }
 
       file[options.property] = content.attributes;
       if (options.remove) {
         file.contents = new Buffer(content.body);
       }
-    } else {
+    } else if (file.isNull()) {
+      return cb(null, file);
+    } else  {
       // stream
       // @ToDo implement the stream handling 
-      return cb(new Error('gulp-front-matter: Cannot get the front matter in a stream'), file);
+      return cb(new gutil.PluginError(PLUGIN_NAME, 'gulp-front-matter: Cannot get the front matter in a stream'));
     }
 
     cb(null, file);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "devDependencies": {
     "chai": "~1.8.1",
     "mocha": "~1.17.0",
-    "gulp": "~3.4.0"
+    "gulp": "~3.4.0",
+    "gulp-util": "~2.2.14"
   },
   "engines": {
     "node": ">=0.9.0"

--- a/test/gulp-front-matter.js
+++ b/test/gulp-front-matter.js
@@ -1,11 +1,13 @@
 "use strict";
 
 var gulp = require('gulp');
+var gutil = require('gulp-util');
 var expect = require('chai').expect;
 
 var es = require('event-stream');
 var fs = require('fs');
 var path = require('path');
+var stream = require('stream');
 
 var frontMatter = require('../');
 
@@ -46,4 +48,29 @@ describe('gulp-front-matter', function() {
     expect(file.data).to.be.an('object').and.have.property('layout');
     cb();
   }));
+
+  it ('should raise a plugin error for stream file', function (done) {
+    var streamFile = new gutil.File({ contents: new stream.Stream() });
+    var fm = frontMatter()
+      .on('error', function (err) {
+        expect(err).to.be.an.instanceOf(gutil.PluginError);
+        done();
+      })
+      .on('end', function () {
+        done(new Error('Stream end without error'));
+      });
+    fm.write(streamFile);
+    fm.end();
+  });
+
+  it ('should get null file through', function (done) {
+    var nullFile = new gutil.File();
+    var fm = frontMatter()
+      .on('data', function (file) {
+        expect(file).to.be.equal(nullFile);
+      })
+      .on('end', done);
+    fm.write(nullFile);
+    fm.end();
+  });
 });


### PR DESCRIPTION
Currently this plugin regards null files as stream files and emits errors. This behavior is problematic for some cases and also violates [the guidelines of gulp](https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/guidelines.md). So I modified it to ignore null files and pass them along.
