### PR TITLE
Moved gulp-util from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   "homepage": "https://github.com/lmtm/gulp-front-matter",
   "dependencies": {
     "front-matter": "~0.2.0",
+    "gulp-util": "~2.2.14",
     "lodash": "~2.4.1",
     "map-stream": "^0.1.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",
     "mocha": "~1.20.1",
-    "gulp": "~3.8.6",
-    "gulp-util": "~2.2.14"
+    "gulp": "~3.8.6"
   },
   "engines": {
     "node": ">=0.9.0"


### PR DESCRIPTION
`gulp-util` is now being required in `index.js` so it's an actual dependency, not just a dev dependency.
